### PR TITLE
[CMSP-616] Update WPCS to 3.0

### DIFF
--- a/Pantheon-WP/ruleset.xml
+++ b/Pantheon-WP/ruleset.xml
@@ -19,7 +19,7 @@
 		<exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine" />
 		<exclude name="PEAR.Functions.FunctionCallSignature.MultipleArguments" />
 		<exclude name="WordPress.Arrays.MultipleStatementAlignment.DoubleArrowNotAligned" />
-		<exclude name="WordPress.PHP.DisallowShortTernary.Found" />
+		<exclude name="Universal.Operators.DisallowShortTernary.Found" />
 		<!--
 		The following was written by Ryan McCue in the HM Coding Standards.
 		I tend to agree with the argument that Yoda conditions are ridiculous

--- a/Pantheon-WP/ruleset.xml
+++ b/Pantheon-WP/ruleset.xml
@@ -13,7 +13,7 @@
 	<!-- Rulesets to use -->
 	<rule ref="PHPCompatibilityWP" />
 	<rule ref="WordPress-Core">
-		<exclude name="Generic.Arrays.DisallowShortArraySyntax" />
+		<exclude name="Universal.Arrays.DisallowShortArraySyntax" />
 		<exclude name="Generic.Formatting.MultipleStatementAlignment.NotSameWarning" />
 		<exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket" />
 		<exclude name="PEAR.Functions.FunctionCallSignature.CloseBracketLine" />

--- a/composer.json
+++ b/composer.json
@@ -12,10 +12,10 @@
     "minimum-stability": "dev",
     "prefer-stable": true,
     "require": {
-        "automattic/vipwpcs": "^2.3",
+        "automattic/vipwpcs": "^3.0",
         "fig-r/psr2r-sniffer": "^1.5",
         "phpcompatibility/phpcompatibility-wp": "^2.1",
-        "wp-coding-standards/wpcs": "^2.3"
+        "wp-coding-standards/wpcs": "^3.0"
     },
     "require-dev": {
         "phpunit/phpunit": "9.6.x-dev",


### PR DESCRIPTION
This updates our WP Coding Standards dependency to 3.0. By necessity, we also update the VIP WPCS standards to 3.0.

A couple rules are updated to `Universal` from updated PHPCS, otherwise there are no major changes. 

This should be a major release due to breaking changes in the rules. Additional tweaks may be necessary, but marking ready for review/merge now so we can put out RCs and test the RCs against our plugins (rather than testing the plugins against a specific branch).