### PR TITLE
Remove outdated sniff

### DIFF
--- a/Pantheon-WP-Minimum/ruleset.xml
+++ b/Pantheon-WP-Minimum/ruleset.xml
@@ -66,10 +66,6 @@
 
 	<!-- Require correct usage of WP's i18n functions. -->
 	<rule ref="WordPress.WP.I18n">
-		<properties>
-			<property name="check_translator_comments" value="false" />
-		</properties>
-
 		<!-- Allow empty strings to be translated (e.g. space character) -->
 		<exclude name="WordPress.WP.I18n.NoEmptyStrings" />
 


### PR DESCRIPTION
This sniff no longer exists.

Fixes failing lint tests in https://github.com/pantheon-systems/pantheon-mu-plugin/pull/28

Will need a new release after merge.