### PR TITLE
Exclude linting warning for `$_SERVER['HTTP_USER_AGENT']`

### DIFF
--- a/Pantheon-WP/ruleset.xml
+++ b/Pantheon-WP/ruleset.xml
@@ -47,6 +47,7 @@
 	<rule ref="WordPressVIPMinimum">
 		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get" />
 		<exclude name="WordPressVIPMinimum.Files.IncludingFile.UsingVariable" />
+		<exclude name="WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__" />
 	</rule>
 
 	<!-- Rule exclusions -->


### PR DESCRIPTION
This pull request excludes the linting warning for the use of `$_SERVER['HTTP_USER_AGENT']` in the codebase. This removes an unnecessary linting check for VIP-specific standards.

Triggering warnings in https://github.com/pantheon-systems/pantheon-mu-plugin/actions/runs/9422346573/job/25958426209?pr=48 that are irrelevant

see https://github.com/pantheon-systems/pantheon-mu-plugin/pull/48

cc @al-esc