### PR TITLE
allow or as logical operator

### DIFF
--- a/Pantheon-WP-Minimum/ruleset.xml
+++ b/Pantheon-WP-Minimum/ruleset.xml
@@ -43,6 +43,9 @@
 		<type>error</type>
 		<message>eval() is a security risk and is not allowed.</message>
 	</rule>
+	<rule ref="Squiz.Operators.ValidLogicalOperators">
+		<exclude name="Squiz.Operators.ValidLogicalOperators.NotAllowed" />
+	</rule>
 
 	<!-- Disallow create_function() -->
 	<rule ref="WordPress.PHP.RestrictedPHPFunctions"/>


### PR DESCRIPTION
This PR allows `or` as a valid logical operator (e.g. in the pattern `defined( 'CONSTANT' ) or define( 'CONSTANT', true )` which is not infrequently used in config files.