### PR TITLE
Ignore PHP errors related to the version being run

### DIFF
--- a/Pantheon-WP-Minimum/ruleset.xml
+++ b/Pantheon-WP-Minimum/ruleset.xml
@@ -82,4 +82,7 @@
 
 	<!-- Require valid syntax. -->
 	<rule ref="Generic.PHP.Syntax" />
+
+	<!-- Ignore PHP-related errors. -->
+	<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />
 </ruleset>

--- a/Pantheon-WP/ruleset.xml
+++ b/Pantheon-WP/ruleset.xml
@@ -70,4 +70,7 @@
 
 	<!-- Ban inline assignment in control structures (see note on Yoda Conditions above). -->
 	<rule ref="PSR2R.ControlStructures.NoInlineAssignment" />
+
+	<!-- Ignore PHP-related errors. -->
+	<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />	
 </ruleset>


### PR DESCRIPTION
This is an issue that is likely coming from PHPCompatibility or PHPCompatibility-WP. The issue was present in WPCS (but fixed in 3.0). There is no real benefit for leaving error reporting in when it has to do with a CS ruleset, so I think we can safely just ignore errors.
See: https://github.com/WordPress/WordPress-Coding-Standards/issues/2035
See also: https://gist.github.com/shreyasikhar/f4495ac952586096eb81d505e9e914a4