### PR TITLE
Add @pantheon-systems/devrel to codeowners for coding standards

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,2 @@
 * @pantheon-systems/site-experience
+* @pantheon-systems/devrel

--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,2 +1,1 @@
-* @pantheon-systems/site-experience
-* @pantheon-systems/devrel
+* @pantheon-systems/site-experience @pantheon-systems/devrel


### PR DESCRIPTION
Include @pantheon-systems/devrel in the coding standards codeowners 