### PR TITLE
Add Pantheon-WP coding standards for comment usage

### DIFF
--- a/Pantheon-WP-Minimum/Sniffs/Commenting/DisallowMultilineSlashCommentSniff.php
+++ b/Pantheon-WP-Minimum/Sniffs/Commenting/DisallowMultilineSlashCommentSniff.php
@@ -25,34 +25,59 @@ class DisallowMultilineSlashCommentSniff implements Sniff {
 	}
 
 	/**
-		* Processes this test, when one of its tokens is encountered.
-		*
-		* @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
-		* @param int                         $stackPtr  The position of the current token in the
-		*                                               stack passed in $tokens.
-		*
-		* @return void
-		*/
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the current token in the
+	 *                                               stack passed in $tokens.
+	 *
+	 * @return void
+	 */
 	public function process( File $phpcsFile, $stackPtr ) {
+		self::getConsecutiveSingleLineComments( $phpcsFile, $stackPtr );
+	}
+
+	/**
+	 * Checks for consecutive single-line comments and reports them.
+	 *
+	 * @param File $phpcsFile The file being scanned.
+	 * @param int  $stackPtr  The position of the current token in the stack.
+	 *
+	 * @return void
+	 */
+	public static function getConsecutiveSingleLineComments( File $phpcsFile, $stackPtr ) {
 		$tokens = $phpcsFile->getTokens();
+		$token  = $tokens[ $stackPtr ];
 
 		// We are only interested in single-line comments.
-		if ( '//' !== substr( $tokens[ $stackPtr ]['content'], 0, 2 ) ) {
+		if ( '//' !== substr( $token['content'], 0, 2 ) ) {
 			return;
 		}
 
-		$nextComment = $phpcsFile->findNext( T_COMMENT, $stackPtr + 1 );
-		if ( false === $nextComment ) {
-			return;
-		}
-
-		// Check if the next comment is on the next line.
-		if ( $tokens[ $nextComment ]['line'] === $tokens[ $stackPtr ]['line'] + 1 ) {
-			// Check if the next comment is also a single-line comment.
-			if ( '//' === substr( $tokens[ $nextComment ]['content'], 0, 2 ) ) {
-				$error = 'Multiline comments should use /* ... */ syntax, not multiple // comments.';
-				$phpcsFile->addWarning( $error, $stackPtr, 'Found' );
+		// Check the previous line to see if we are already in a block.
+		$prevLine = $token['line'] - 1;
+		$prevComment = $phpcsFile->findPrevious( T_COMMENT, $stackPtr - 1, null, false, null, true );
+		if ( false !== $prevComment && $tokens[$prevComment]['line'] === $prevLine ) {
+			if ( '//' === substr( $tokens[$prevComment]['content'], 0, 2 ) ) {
+				return; // This is not the start of the block.
 			}
+		}
+
+		// This is the start of a block. Now, count how many lines it spans.
+		$lineCount = 1;
+		$nextComment = $stackPtr;
+		while ( true ) {
+			$nextComment = $phpcsFile->findNext( T_COMMENT, $nextComment + 1, null, false, null, true );
+			if ( false === $nextComment || $tokens[$nextComment]['line'] !== ( $token['line'] + $lineCount ) ) {
+				break; // The block has ended.
+			}
+			$lineCount++;
+		}
+
+		if ( $lineCount > 1 ) {
+			$message = 'A block of %s consecutive single-line comments was found starting on this line. Please use a /* ... */ block instead.';
+			$data    = [ $lineCount ];
+			$phpcsFile->addWarning( $message, $stackPtr, 'Found', $data );
 		}
 	}
 }

--- a/Pantheon-WP-Minimum/Sniffs/Commenting/DisallowMultilineSlashCommentSniff.php
+++ b/Pantheon-WP-Minimum/Sniffs/Commenting/DisallowMultilineSlashCommentSniff.php
@@ -42,10 +42,11 @@ class DisallowMultilineSlashCommentSniff implements Sniff {
 	 *
 	 * @param File $phpcsFile The file being scanned.
 	 * @param int  $stackPtr  The position of the current token in the stack.
+	 * @param string $error    The type of error to report ('warning' or 'error').
 	 *
 	 * @return void
 	 */
-	public static function getConsecutiveSingleLineComments( File $phpcsFile, $stackPtr ) {
+	public static function getConsecutiveSingleLineComments( File $phpcsFile, $stackPtr, $error = 'warning' ) {
 		$tokens = $phpcsFile->getTokens();
 		$token  = $tokens[ $stackPtr ];
 
@@ -77,7 +78,11 @@ class DisallowMultilineSlashCommentSniff implements Sniff {
 		if ( $lineCount > 1 ) {
 			$message = 'A block of %s consecutive single-line comments was found starting on this line. Please use a /* ... */ block instead.';
 			$data    = [ $lineCount ];
-			$phpcsFile->addWarning( $message, $stackPtr, 'Found', $data );
+			if ( 'warning' === $error ) {
+				$phpcsFile->addWarning( $message, $stackPtr, 'Found', $data );
+			} else {
+				$phpcsFile->addError( $message, $stackPtr, 'Found', $data );
+			}
 		}
 	}
 }

--- a/Pantheon-WP-Minimum/Sniffs/Commenting/DisallowMultilineSlashCommentSniff.php
+++ b/Pantheon-WP-Minimum/Sniffs/Commenting/DisallowMultilineSlashCommentSniff.php
@@ -1,0 +1,58 @@
+<?php
+/**
+ * Verifies that multiline comments are not used.
+ *
+ * @package Pantheon-WP-Minimum
+ */
+
+namespace Pantheon_WP_Minimum\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Verifies that multiline comments are not used.
+ */
+class DisallowMultilineSlashCommentSniff implements Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return [ T_COMMENT ];
+	}
+
+	/**
+		* Processes this test, when one of its tokens is encountered.
+		*
+		* @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+		* @param int                         $stackPtr  The position of the current token in the
+		*                                               stack passed in $tokens.
+		*
+		* @return void
+		*/
+	public function process( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+
+		// We are only interested in single-line comments.
+		if ( '//' !== substr( $tokens[ $stackPtr ]['content'], 0, 2 ) ) {
+			return;
+		}
+
+		$nextComment = $phpcsFile->findNext( T_COMMENT, $stackPtr + 1 );
+		if ( false === $nextComment ) {
+			return;
+		}
+
+		// Check if the next comment is on the next line.
+		if ( $tokens[ $nextComment ]['line'] === $tokens[ $stackPtr ]['line'] + 1 ) {
+			// Check if the next comment is also a single-line comment.
+			if ( '//' === substr( $tokens[ $nextComment ]['content'], 0, 2 ) ) {
+				$error = 'Multiline comments should use /* ... */ syntax, not multiple // comments.';
+				$phpcsFile->addWarning( $error, $stackPtr, 'Found' );
+			}
+		}
+	}
+}

--- a/Pantheon-WP-Minimum/ruleset.xml
+++ b/Pantheon-WP-Minimum/ruleset.xml
@@ -41,11 +41,6 @@
 	<rule ref="WordPress.DB.RestrictedFunctions" />
 	<rule ref="WordPress.DB.RestrictedClasses" />
 
-	<!-- Disallow rename() function -->
-	<rule ref="./Sniffs/Files/DisallowRenameFunctionSniff.php">
-		<type>error</type>
-	</rule>
-
 	<!-- Disallow eval(). (From WordPress-Core) -->
 	<rule ref="Squiz.PHP.Eval"/>
 	<rule ref="Squiz.PHP.Eval.Discouraged">
@@ -94,4 +89,14 @@
 
 	<!-- Ignore PHP-related errors. -->
 	<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />
+
+	<!-- Pantheon specific rules -->
+
+	<!-- Disallow rename() function -->
+	<rule ref="./Sniffs/Files/DisallowRenameFunctionSniff.php">
+		<type>error</type>
+	</rule>
+
+	<!-- Disallow multiline // comments -->
+	<rule ref="./Sniffs/Commenting/DisallowMultilineSlashCommentSniff.php"/>
 </ruleset>

--- a/Pantheon-WP/Sniffs/Commenting/DisallowMultilineSlashCommentSniff.php
+++ b/Pantheon-WP/Sniffs/Commenting/DisallowMultilineSlashCommentSniff.php
@@ -39,7 +39,7 @@ class DisallowMultilineSlashCommentSniff implements Sniff {
 		$token  = $tokens[ $stackPtr ];
 
 		// Pull sniff for single-line comments from Pantheon-WP-Minimum.
-		PantheonWPMinimumCommenting::getConsecutiveSingleLineComments( $phpcsFile, $stackPtr );
+		PantheonWPMinimumCommenting::getConsecutiveSingleLineComments( $phpcsFile, $stackPtr, 'error' );
 
 		// Check for long lines within block comments.
 		if ( substr( $token['content'], 0, 2 ) === '/*' ) {

--- a/Pantheon-WP/Sniffs/Commenting/DisallowMultilineSlashCommentSniff.php
+++ b/Pantheon-WP/Sniffs/Commenting/DisallowMultilineSlashCommentSniff.php
@@ -9,6 +9,7 @@ namespace Pantheon_WP\Sniffs\Commenting;
 
 use PHP_CodeSniffer\Files\File;
 use PHP_CodeSniffer\Sniffs\Sniff;
+use Pantheon_WP_Minimum\Sniffs\Commenting\DisallowMultilineSlashCommentSniff as PantheonWPMinimumCommenting;
 
 /**
  * Verifies that multiline comments are not used.
@@ -37,17 +38,8 @@ class DisallowMultilineSlashCommentSniff implements Sniff {
 		$tokens = $phpcsFile->getTokens();
 		$token  = $tokens[ $stackPtr ];
 
-		// Check for consecutive single-line comments.
-		if ( '//' === substr( $token['content'], 0, 2 ) ) {
-			$nextComment = $phpcsFile->findNext( T_COMMENT, $stackPtr + 1 );
-			if ( false !== $nextComment && $tokens[ $nextComment ]['line'] === $token['line'] + 1 ) {
-				if ( '//' === substr( $tokens[ $nextComment ]['content'], 0, 2 ) ) {
-					$error = 'Multiline comments should use /* ... */ syntax, not multiple // comments.';
-					$phpcsFile->addError( $error, $stackPtr, 'Found' );
-				}
-			}
-			return;
-		}
+		// Pull sniff for single-line comments from Pantheon-WP-Minimum.
+		PantheonWPMinimumCommenting::getConsecutiveSingleLineComments( $phpcsFile, $stackPtr );
 
 		// Check for long lines within block comments.
 		if ( substr( $token['content'], 0, 2 ) === '/*' ) {

--- a/Pantheon-WP/Sniffs/Commenting/DisallowMultilineSlashCommentSniff.php
+++ b/Pantheon-WP/Sniffs/Commenting/DisallowMultilineSlashCommentSniff.php
@@ -1,0 +1,81 @@
+<?php
+/**
+ * Verifies that multiline comments are not used.
+ *
+ * @package Pantheon-WP
+ */
+
+namespace Pantheon_WP\Sniffs\Commenting;
+
+use PHP_CodeSniffer\Files\File;
+use PHP_CodeSniffer\Sniffs\Sniff;
+
+/**
+ * Verifies that multiline comments are not used.
+ */
+class DisallowMultilineSlashCommentSniff implements Sniff {
+
+	/**
+	 * Returns an array of tokens this test wants to listen for.
+	 *
+	 * @return array
+	 */
+	public function register() {
+		return [ T_COMMENT ];
+	}
+
+	/**
+	 * Processes this test, when one of its tokens is encountered.
+	 *
+	 * @param \PHP_CodeSniffer\Files\File $phpcsFile The file being scanned.
+	 * @param int                         $stackPtr  The position of the current token in the
+	 *                                               stack passed in $tokens.
+	 *
+	 * @return void
+	 */
+	public function process( File $phpcsFile, $stackPtr ) {
+		$tokens = $phpcsFile->getTokens();
+		$token  = $tokens[ $stackPtr ];
+
+		// Check for consecutive single-line comments.
+		if ( '//' === substr( $token['content'], 0, 2 ) ) {
+			$nextComment = $phpcsFile->findNext( T_COMMENT, $stackPtr + 1 );
+			if ( false !== $nextComment && $tokens[ $nextComment ]['line'] === $token['line'] + 1 ) {
+				if ( '//' === substr( $tokens[ $nextComment ]['content'], 0, 2 ) ) {
+					$error = 'Multiline comments should use /* ... */ syntax, not multiple // comments.';
+					$phpcsFile->addError( $error, $stackPtr, 'Found' );
+				}
+			}
+			return;
+		}
+
+		// Check for long lines within block comments.
+		if ( substr( $token['content'], 0, 2 ) === '/*' ) {
+			// First, check the line of the starting token itself.
+			if ( $tokens[$stackPtr]['length'] > 80 ) {
+				$warning = 'For readability, it is recommended to break long comment lines into multiple lines.';
+				$phpcsFile->addWarning( $warning, $stackPtr, 'LongLine' );
+				return; // Only one warning per comment block.
+			}
+
+			// Then, iterate through subsequent tokens on following lines.
+			for ( $i = ( $stackPtr + 1 ); $i < count( $tokens ); $i++ ) {
+				// Stop if we are no longer in a comment.
+				if ( $tokens[$i]['code'] !== T_COMMENT ) {
+					break;
+				}
+
+				// Stop if the line doesn't start with a star, indicating the end of the block.
+				if ( strpos( trim( $tokens[$i]['content'] ), '*' ) !== 0 ) {
+					break;
+				}
+
+				if ( $tokens[$i]['length'] > 80 ) {
+					$warning = 'For readability, it is recommended to break long comment lines into multiple lines.';
+					$phpcsFile->addWarning( $warning, $i, 'LongLine' );
+					return; // Only one warning per comment block.
+				}
+			}
+		}
+	}
+}

--- a/Pantheon-WP/ruleset.xml
+++ b/Pantheon-WP/ruleset.xml
@@ -8,7 +8,9 @@
 	<arg name="extensions" value="php" />
 
 	<!-- Include everything in the minimum ruleset -->
-	<rule ref="Pantheon-WP-Minimum" />
+	<rule ref="Pantheon-WP-Minimum">
+		<exclude name="Pantheon_WP_Minimum.Commenting.DisallowMultilineSlashComment.Found" />
+	</rule>
 
 	<!-- Rulesets to use -->
 	<rule ref="PHPCompatibilityWP" />

--- a/Pantheon-WP/ruleset.xml
+++ b/Pantheon-WP/ruleset.xml
@@ -84,5 +84,8 @@
 	<rule ref="PSR2R.ControlStructures.NoInlineAssignment" />
 
 	<!-- Ignore PHP-related errors. -->
-	<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />	
+	<ini name="error_reporting" value="E_ALL &#38; ~E_DEPRECATED" />
+
+	<!-- Pantheon-WP Sniffs -->
+	<rule ref="./Sniffs/Commenting/DisallowMultilineSlashCommentSniff.php"/>
 </ruleset>

--- a/Pantheon-WP/ruleset.xml
+++ b/Pantheon-WP/ruleset.xml
@@ -52,6 +52,14 @@
 		<exclude name="WordPressVIPMinimum.Files.IncludingFile.UsingVariable" />
 		<exclude name="WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__" />
 		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_rename" />
+
+		<!-- Exclude CSS/JS rules that are deprecated in PHPCS 3.x -->
+		<exclude name="WordPressVIPMinimum.JS.Window" />
+		<exclude name="WordPressVIPMinimum.JS.DangerouslySetInnerHTML" />
+		<exclude name="WordPressVIPMinimum.JS.InnerHTML" />
+		<exclude name="WordPressVIPMinimum.JS.StrippingTags" />
+		<exclude name="WordPressVIPMinimum.JS.StringConcat" />
+		<exclude name="WordPressVIPMinimum.JS.HTMLExecutingFunctions" />
 	</rule>
 
 	<!-- Rule exclusions -->

--- a/Pantheon-WP/ruleset.xml
+++ b/Pantheon-WP/ruleset.xml
@@ -15,6 +15,7 @@
 	<!-- Rulesets to use -->
 	<rule ref="PHPCompatibilityWP" />
 	<rule ref="WordPress-Core">
+		<exclude name="Generic.Functions.CallTimePassByReference" />
 		<exclude name="Universal.Arrays.DisallowShortArraySyntax" />
 		<exclude name="Generic.Formatting.MultipleStatementAlignment.NotSameWarning" />
 		<exclude name="PEAR.Functions.FunctionCallSignature.ContentAfterOpenBracket" />
@@ -50,6 +51,7 @@
 		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.wp_remote_get_wp_remote_get" />
 		<exclude name="WordPressVIPMinimum.Files.IncludingFile.UsingVariable" />
 		<exclude name="WordPressVIPMinimum.Variables.RestrictedVariables.cache_constraints___SERVER__HTTP_USER_AGENT__" />
+		<exclude name="WordPressVIPMinimum.Functions.RestrictedFunctions.file_ops_rename" />
 	</rule>
 
 	<!-- Rule exclusions -->

--- a/composer.json
+++ b/composer.json
@@ -21,9 +21,10 @@
         "squizlabs/php_codesniffer": "^3.13",
         "yoast/phpunit-polyfills": "4.0.0"
     },
-    "autoload-dev": {
+    "autoload": {
         "psr-4": {
-            "Pantheon_WP_Minimum\\": "Pantheon-WP-Minimum/"
+            "Pantheon_WP_Minimum\\": "Pantheon-WP-Minimum/",
+            "Pantheon_WP\\": "Pantheon-WP/"
         }
     },
     "config": {

--- a/composer.json
+++ b/composer.json
@@ -34,8 +34,21 @@
         }
     },
     "scripts": {
+        "lint:minimum": [
+            "vendor/bin/phpcs -s ./tests --standard=./Pantheon-WP-Minimum/ruleset.xml"
+        ],
+        "lint:standard": [
+            "vendor/bin/phpcs -s ./tests --standard=./Pantheon-WP/ruleset.xml"
+        ],
+        "test:minimum": [
+            "for test_file in tests/*.php; do ./tests/run-test.sh Pantheon-WP-Minimum \"$test_file\"; done"
+        ],
+        "test:standard": [
+            "for test_file in tests/*.php; do ./tests/run-test.sh Pantheon-WP \"$test_file\"; done"
+        ],
         "test": [
-            "./tests/run-test.sh tests/*.php"
+            "@test:minimum",
+            "@test:standard"
         ]
     }
 }

--- a/tests/run-test.sh
+++ b/tests/run-test.sh
@@ -18,19 +18,18 @@ fi
 TEST_NAME=$(sed -n '3s/ \* //p' "$TEST_FILE")
 
 echo ""
-echo "Running test: $TEST_NAME with ruleset: $RULESET"
+echo "Running test: ${TEST_NAME} with ruleset: $RULESET"
 echo "$TEST_FILE"
 
 # Use --basepath=. to ensure relative paths in the report.
 JSON_REPORT=$(phpcs --standard="./$RULESET/ruleset.xml" --report=json --basepath=. "$TEST_FILE" 2>/dev/null | sed -n '/{/,$p')
 
 # Debug
-# echo "JSON Report:"
-# echo "$JSON_REPORT"
+# echo "JSON Report: ${JSON_REPORT}"
 
-# Extract actual and expected errors.
-ACTUAL_OUTPUT=$(echo "$JSON_REPORT" | jq -r '.files."'"$TEST_FILE"'".messages[]?.source' | sort)
-EXPECTED_OUTPUT=$( (sed -n "s/.*@expectedError\[$RULESET\] //p" "$TEST_FILE"; sed -n "s/.*@expectedWarning\[$RULESET\] //p" "$TEST_FILE") | sort)
+# Extract actual and expected errors, including severity.
+ACTUAL_OUTPUT=$(echo "$JSON_REPORT" | jq -r '.files."'"$TEST_FILE"'".messages[] | "[\(.type | ascii_upcase)] \(.source)"' | sort)
+EXPECTED_OUTPUT=$( (sed -n "s/.*@expectedError\[$RULESET\] /\[ERROR\] /p" "$TEST_FILE"; sed -n "s/.*@expectedWarning\[$RULESET\] /\[WARNING\] /p" "$TEST_FILE") | sort)
 
 echo "--------------------------------------------------"
 echo "EXPECTED ISSUES:"

--- a/tests/run-test.sh
+++ b/tests/run-test.sh
@@ -48,5 +48,6 @@ if ! diff <(echo "$ACTUAL_OUTPUT") <(echo "$EXPECTED_OUTPUT") > /dev/null; then
 fi
 
 echo "RESULT: PASSED ✅"
-printf "\n"
+echo ""
+
 exit 0

--- a/tests/run-test.sh
+++ b/tests/run-test.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -e
 
 RULESET=$1
 TEST_FILE=$2
@@ -13,7 +14,11 @@ if [ ! -f "$TEST_FILE" ]; then
     exit 1
 fi
 
-echo "Running test: $TEST_FILE with ruleset: $RULESET"
+TEST_NAME=$(sed -n '3s/ \* //p' "$TEST_FILE")
+
+echo ""
+echo "Running test: $TEST_NAME with ruleset: $RULESET"
+echo "$TEST_FILE"
 
 # Use --basepath=. to ensure relative paths in the report.
 JSON_REPORT=$(phpcs --standard="./$RULESET/ruleset.xml" --report=json --basepath=. "$TEST_FILE" 2>/dev/null | sed -n '/{/,$p')

--- a/tests/run-test.sh
+++ b/tests/run-test.sh
@@ -43,5 +43,5 @@ if ! diff <(echo "$ACTUAL_OUTPUT") <(echo "$EXPECTED_OUTPUT") > /dev/null; then
 fi
 
 echo "RESULT: PASSED ✅"
-echo -e "\n"
+printf "\n"
 exit 0

--- a/tests/run-test.sh
+++ b/tests/run-test.sh
@@ -43,4 +43,5 @@ if ! diff <(echo "$ACTUAL_OUTPUT") <(echo "$EXPECTED_OUTPUT") > /dev/null; then
 fi
 
 echo "RESULT: PASSED ✅"
+echo -e "\n"
 exit 0

--- a/tests/run-test.sh
+++ b/tests/run-test.sh
@@ -14,6 +14,7 @@ if [ ! -f "$TEST_FILE" ]; then
     exit 1
 fi
 
+# Get the test name from the file header.
 TEST_NAME=$(sed -n '3s/ \* //p' "$TEST_FILE")
 
 echo ""
@@ -48,6 +49,6 @@ if ! diff <(echo "$ACTUAL_OUTPUT") <(echo "$EXPECTED_OUTPUT") > /dev/null; then
 fi
 
 echo "RESULT: PASSED ✅"
-echo ""
+echo " "
 
 exit 0

--- a/tests/test-disallow-multiline-slash-comment.php
+++ b/tests/test-disallow-multiline-slash-comment.php
@@ -2,8 +2,9 @@
 /**
  * Disallow usage of multiline slash comments.
  *
- * @expectedError Pantheon_WP_Minimum.Commenting.DisallowMultilineSlashComment.Found
- * @expectedWarning Pantheon_WP_Minimum.Commenting.DisallowMultilineSlashComment.LongLine
+ * @expectedWarning[Pantheon-WP-Minimum] Pantheon_WP_Minimum.Commenting.DisallowMultilineSlashComment.Found
+ * @expectedError[Pantheon-WP] Pantheon_WP.Commenting.DisallowMultilineSlashComment.Found
+ * @expectedWarning[Pantheon-WP] Pantheon_WP.Commenting.DisallowMultilineSlashComment.LongLine
  *
  * @package Pantheon-WP-Coding-Standards
  */
@@ -22,8 +23,8 @@
 /*
  * This comment is ideal. It uses the correct syntax and is not too long.
  * What's with the life preserver? Doc, she's beautiful. She's crazy about me.
- * Look at this, look what she wrote me, Doc. That says it all. Doc, you're my 
- * only hope. Oh, uh, hey you, get your damn hands off her. Do you really think 
- * I oughta swear? Well, now we gotta sneak this back into my laboratory, we've 
+ * Look at this, look what she wrote me, Doc. That says it all. Doc, you're my
+ * only hope. Oh, uh, hey you, get your damn hands off her. Do you really think
+ * I oughta swear? Well, now we gotta sneak this back into my laboratory, we've
  * gotta get you home. Jennifer.
  */

--- a/tests/test-disallow-multiline-slash-comment.php
+++ b/tests/test-disallow-multiline-slash-comment.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * Disallow usage of multiline slash comments.
+ * Multiline comments should use /* syntax.
  *
  * @expectedWarning[Pantheon-WP-Minimum] Pantheon_WP_Minimum.Commenting.DisallowMultilineSlashComment.Found
  * @expectedError[Pantheon-WP] Pantheon_WP.Commenting.DisallowMultilineSlashComment.Found

--- a/tests/test-disallow-multiline-slash-comment.php
+++ b/tests/test-disallow-multiline-slash-comment.php
@@ -1,0 +1,29 @@
+<?php
+/**
+ * Disallow usage of multiline slash comments.
+ *
+ * @expectedError Pantheon_WP_Minimum.Commenting.DisallowMultilineSlashComment.Found
+ * @expectedWarning Pantheon_WP_Minimum.Commenting.DisallowMultilineSlashComment.LongLine
+ *
+ * @package Pantheon-WP-Coding-Standards
+ */
+
+// This comment should fail with a warning.
+// Multiline comments should use /* ... */ syntax, not multiple // comments.
+// What's with the life preserver? Doc, she's beautiful. She's crazy about me. Look at this,
+// look what she wrote me, Doc. That says it all. Doc, you're my only hope. Oh, uh, hey you,
+// get your damn hands off her. Do you really think I oughta swear? Well, now we gotta sneak
+// this back into my laboratory, we've gotta get you home. Jennifer.
+
+/*
+ * This comment should not fail but should trigger an info to break the comment up. What's with the life preserver? Doc, she's beautiful. She's crazy about me. Look at this, look what she wrote me, Doc. That says it all. Doc, you're my only hope. Oh, uh, hey you, get your damn hands off her. Do you really think I oughta swear? Well, now we gotta sneak this back into my laboratory, we've gotta get you home. Jennifer.
+ */
+
+/*
+ * This comment is ideal. It uses the correct syntax and is not too long.
+ * What's with the life preserver? Doc, she's beautiful. She's crazy about me.
+ * Look at this, look what she wrote me, Doc. That says it all. Doc, you're my 
+ * only hope. Oh, uh, hey you, get your damn hands off her. Do you really think 
+ * I oughta swear? Well, now we gotta sneak this back into my laboratory, we've 
+ * gotta get you home. Jennifer.
+ */

--- a/tests/test-disallow-rename-function.php
+++ b/tests/test-disallow-rename-function.php
@@ -2,7 +2,8 @@
 /**
  * DisallowRenameFunctionTest.inc
  *
- * @expectedError Pantheon_WP_Minimum.Files.DisallowRenameFunction.RenameFunctionDisallowed
+ * @expectedError[Pantheon-WP-Minimum] Pantheon_WP_Minimum.Files.DisallowRenameFunction.RenameFunctionDisallowed
+ * @expectedError[Pantheon-WP] Pantheon_WP_Minimum.Files.DisallowRenameFunction.RenameFunctionDisallowed
  *
  * @package Pantheon-WP-Coding-Standards
  */

--- a/tests/test-disallow-rename-function.php
+++ b/tests/test-disallow-rename-function.php
@@ -1,6 +1,6 @@
 <?php
 /**
- * DisallowRenameFunctionTest.inc
+ * Disallow usage of the rename() function.
  *
  * @expectedError[Pantheon-WP-Minimum] Pantheon_WP_Minimum.Files.DisallowRenameFunction.RenameFunctionDisallowed
  * @expectedError[Pantheon-WP] Pantheon_WP_Minimum.Files.DisallowRenameFunction.RenameFunctionDisallowed


### PR DESCRIPTION
This PR adds a new sniff enforcing commenting guidelines.
Multiple consecutive `//` comments reports a `WARNING` in `Pantheon-WP-Minimum` and an `ERROR` in `Pantheon-WP`.
Long `/* ... */` comments (> 80 columns) reports an `ERROR` in `Pantheon-WP`.

Test framework has been updated to support passing the specific ruleset in to test the sniffs against those rules.
Composer scripts have been added to make it easier to test the sniffs and run the tests against specific rulesets.

fixes #1